### PR TITLE
Refactoring dbt commands

### DIFF
--- a/mara_dbt/commands.py
+++ b/mara_dbt/commands.py
@@ -148,8 +148,10 @@ class DbtSeed(_DbtSelectCommand):
                        overrides variables defined in config.dbt_variables()
         """
         if select is None and 'models' in kargs:
+            warn("Use parameter 'select' instead of 'models' in command DbtRun", DeprecationWarning, stacklevel=2)
             select = kargs['model']
         if exclude is None and 'exclude_models' in kargs:
+            warn("Use parameter 'exclude' instead of 'exclude_models' command DbtRun", DeprecationWarning, stacklevel=2)
             exclude = kargs['exclude_models']
         super().__init__('seed', select=select, exclude=exclude, selector=selector, full_refresh=full_refresh,
                          target=target, variables=variables)
@@ -192,8 +194,10 @@ class DbtSnapshot(_DbtSelectCommand):
                        overrides variables defined in config.dbt_variables()
         """
         if select is None and 'models' in kargs:
+            warn("Use parameter 'select' instead of 'models' in command DbtRun", DeprecationWarning, stacklevel=2)
             select = kargs['model']
         if exclude is None and 'exclude_models' in kargs:
+            warn("Use parameter 'exclude' instead of 'exclude_models' command DbtRun", DeprecationWarning, stacklevel=2)
             exclude = kargs['exclude_models']
         super().__init__('run', select=select, exclude=exclude, selector=selector,
                          target=target, variables=variables)
@@ -218,8 +222,10 @@ class DbtRun(_DbtSelectCommand):
                        overrides variables defined in config.dbt_variables()
         """
         if select is None and 'models' in kargs:
+            warn("Use parameter 'select' instead of 'models' in command DbtRun", DeprecationWarning, stacklevel=2)
             select = kargs['model']
         if exclude is None and 'exclude_models' in kargs:
+            warn("Use parameter 'exclude' instead of 'exclude_models' command DbtRun", DeprecationWarning, stacklevel=2)
             exclude = kargs['exclude_models']
         super().__init__('run', select=select, exclude=exclude, selector=selector, full_refresh=full_refresh,
                          target=target, variables=variables)
@@ -265,8 +271,10 @@ class DbtTest(_DbtSelectCommand):
                        overrides variables defined in config.dbt_variables()
         """
         if select is None and 'models' in kargs:
+            warn("Use parameter 'select' instead of 'models' in command DbtRun", DeprecationWarning, stacklevel=2)
             select = kargs['model']
         if exclude is None and 'exclude_models' in kargs:
+            warn("Use parameter 'exclude' instead of 'exclude_models' command DbtRun", DeprecationWarning, stacklevel=2)
             exclude = kargs['exclude_models']
         super().__init__('test', select=select, exclude=exclude, selector=selector,
                          target=target, variables=variables)

--- a/mara_dbt/commands.py
+++ b/mara_dbt/commands.py
@@ -1,5 +1,6 @@
 import json
 import shlex
+from warnings import warn
 
 from mara_page import _
 from mara_pipelines.pipelines import Command
@@ -229,7 +230,7 @@ class _DbtCloudCommand(Command):
                 'dbt-cloud')
 
 
-class RunDbtJob(_DbtCloudCommand):
+class RunDbtCloudJob(_DbtCloudCommand):
     def __init__(self, job_id: int, cause: str = None, wait: bool = True):
         
         """
@@ -250,3 +251,10 @@ class RunDbtJob(_DbtCloudCommand):
             + f' job run --job-id {self.job_id}'
             + (f' --cause {shlex.quote(self.cause)}' if self.cause else '')
             + (' --wait' if self.wait else ''))
+
+
+# deprecated. TBD: Remove in 1.0.0
+class RunDbtJob(RunDbtCloudJob):
+    def __init_subclass__(cls) -> None:
+        warn("Class RunDbtJob has been renamed to RunDbtCloudJob", DeprecationWarning, stacklevel=2)
+        return super().__init_subclass__()


### PR DESCRIPTION
Refactoring the dbt command file:

* add new command `DbtDocsGenerate`, `DepDeps`, `DbtBuild`, `DbtCompile`
* use new naming of arguments according to dbt cli with backport for old args:
  *  use arg `select` instead of arg name `model`
  * use arg `exclude` instead of arg name `exclude_models`
* add new base class _DbtSelectCommand
* rename `RunDbtJob` to `RunDbtCloudJob` (with backport to old naming)
* improve argument typing